### PR TITLE
fix: 增大商品价格失效判断时间为1小时

### DIFF
--- a/utils/log.ts
+++ b/utils/log.ts
@@ -3,6 +3,6 @@ import type { Log } from '~/drizzle/schema';
 export function isLogValid(log: Log | undefined | null): log is Log {
   if (!log) return false;
   const uploadedAt = log.uploadedAt.getTime();
-  // 30 分钟
-  return new Date().getTime() - uploadedAt > 1800 * 1000;
+  // 60 分钟
+  return new Date().getTime() - uploadedAt > 3600 * 1000;
 }


### PR DESCRIPTION
### Description

从老黑雷索纳斯手册里了解到的数据看来，基准价格更新时间是1小时，根据玩家交易量加快，感觉应该用1小时作为失效时间。

并且现在30分钟就失效，数据一眼看上去失效的太多了，给人印象不太好hhh。

### Linked Issues

#16 