### PR TITLE
[新功能] 支持按单票利润排序

### DIFF
--- a/components/City.vue
+++ b/components/City.vue
@@ -100,7 +100,7 @@ const sortCitesByPerTicketProfit = (filteredCities: CityInfo[], sourceCityName: 
         <TableHeader>
           <TableRow class="boder-t">
             <TableHead class="w-[120px]">商品</TableHead>
-            <!-- 按城市纬度排序 -->
+            <!-- 按城市维度排序 -->
             <template v-if="settingStore.listSortMode === 'byCity'">
               <TableHead class="border-r">{{ currentCity.name }}</TableHead>
               <TableHead

--- a/components/City.vue
+++ b/components/City.vue
@@ -58,7 +58,7 @@ const sortCitesByPercent = (filteredCities: CityInfo[], sourceCityName: string, 
   let citiesProfitMap: {[key: string]: number} = {}
   filteredCities.map(city => {
     const latestLog = store.getLatestLog(sourceCityName, productName, city.name)
-    // 如果最新交易记录无效，且有最新交易记录和原产地价格，则计算利润
+    // 如果最新交易记录有效，且有最新交易记录和原产地价格，则计算利润
     const profit = !Boolean(isLogValid(latestLog)) && latestLog && sourceCityPrice ? latestLog.price - sourceCityPrice : -9999
     return { cityName: city.name, profit }
   }).forEach(cityProfit => citiesProfitMap[cityProfit.cityName] = cityProfit.profit)
@@ -76,7 +76,7 @@ const sortCitesByPerTicketProfit = (filteredCities: CityInfo[], sourceCityName: 
   let citiesProfitMap: {[key: string]: number} = {}
   filteredCities.map(city => {
     const latestLog = store.getLatestLog(sourceCityName, productName, city.name)
-    // 如果最新交易记录无效，且有最新交易记录和原产地价格，则计算利润
+    // 如果最新交易记录有效，且有最新交易记录和原产地价格，则计算利润
     const profit = !Boolean(isLogValid(latestLog)) && latestLog && sourceCityPrice ? latestLog.price - sourceCityPrice : -9999
     return { cityName: city.name, profit }
   }).forEach(cityProfit => citiesProfitMap[cityProfit.cityName] = cityProfit.profit)
@@ -133,7 +133,6 @@ const sortCitesByPerTicketProfit = (filteredCities: CityInfo[], sourceCityName: 
             <TableCell
               v-for="target in sortCitesWithSetting(sellCities, city.name, product.name)"
               :key="target.name"
-              :class="{'w-40': settingStore.listSortMode !== 'byCity'}"
             >
               <Price
                 :timestamp="timestamp"
@@ -142,19 +141,9 @@ const sortCitesByPerTicketProfit = (filteredCities: CityInfo[], sourceCityName: 
                 :log="store.getLatestLog(city.name, product.name, target.name)"
               />
             </TableCell>
-            <!-- 操作单元格 -->
-            <TableCell>
-              <CreateLog :source-city-name="city.name" :product="product">
-                <Button variant="outline" size="sm">上报</Button>
-              </CreateLog>
-            </TableCell>
           </TableRow>
         </TableBody>
       </Table>
     </CardContent>
-    <!-- <CardFooter class="flex justify-between px-6 pb-6">
-      <Button variant="outline"> Cancel </Button>
-      <Button>Deploy</Button>
-    </CardFooter> -->
   </Card>
 </template>

--- a/components/City.vue
+++ b/components/City.vue
@@ -116,8 +116,12 @@ const sortCitesByPerTicketProfit = (filteredCities: CityInfo[], sourceCityName: 
             <!-- 按利润排序 -->
             <template v-else>
               <TableHead class="border-r"><div class="w-30">原产地采购价</div></TableHead>
-              <TableHead v-if="settingStore.listSortMode === 'byProfit'" :colspan="sellCities.length">城市售卖报价(按单位利润高低从左到右降序排序)</TableHead>
-              <TableHead v-if="settingStore.listSortMode === 'byPerTicketProfit'" :colspan="sellCities.length">城市售卖报价(按单票利润高低从左到右降序排序)</TableHead>
+              <TableHead :colspan="sellCities.length">
+                城市售卖报价(按
+                {{ settingStore.listSortMode === 'byProfit' ? "单位" : "" }}
+                {{ settingStore.listSortMode === 'byPerTicketProfit' ? "单票" : "" }}
+                利润高低从左到右降序排序)
+              </TableHead>
             </template>
           </TableRow>
         </TableHeader>
@@ -136,14 +140,14 @@ const sortCitesByPerTicketProfit = (filteredCities: CityInfo[], sourceCityName: 
             </TableCell>
             <!-- 被排序过的售出城市列表 -->
             <TableCell
-              v-for="target in sortCitesWithSetting(sellCities, city.name, product.name)"
-              :key="target.name"
+              v-for="targetCity in sortCitesWithSetting(sellCities, city.name, product.name)"
+              :key="`${product.name}-${targetCity.name}`"
             >
               <Price
                 :timestamp="timestamp"
                 :product="getProductInfo(city.name, product.name)!"
-                :transaction="getTransactionInfo(city.name, product.name, target.name)"
-                :log="store.getLatestLog(city.name, product.name, target.name)"
+                :transaction="getTransactionInfo(city.name, product.name, targetCity.name)"
+                :log="store.getLatestLog(city.name, product.name, targetCity.name)"
               />
             </TableCell>
           </TableRow>

--- a/components/Price.vue
+++ b/components/Price.vue
@@ -14,17 +14,20 @@ const props = defineProps<{
 
 const settingStore = useSettingStore()
 
+const store = useLatestLogs();
+
+// 受控的 Tooltip 打开状态
 const openTooltip = ref(false);
 
+// 受控的 上报价格对话框 打开状态
 const reportDialogVisible = ref(false);
 
+// 记录是否已过期
 const isOutdated = computed(() => {
   if (!props.log) return true;
   props.timestamp;
   return isLogValid(props.log);
 });
-
-const store = useLatestLogs();
 
 // 单位利润
 const profit = computed(() => {
@@ -44,6 +47,7 @@ const perTicketProfit = computed(() => {
   return (profit.value ?? 0) * (props.product.baseVolume ?? 0);
 });
 
+// 单位利润颜色
 const profitColor = computed(() => {
   if (profit.value === undefined || isOutdated.value) return undefined;
   const value = +profit.value;
@@ -131,11 +135,9 @@ const shortTime = computed(() => {
             <!-- 涨跌百分比 -->
             <div :class="['h-6 flex gap-1 items-center', { 'line-through': isOutdated }]">
               <span class="i-icon-park-outline-chart-line text-base-600 text-sm"></span>
-              <span :class="{ 'text-red': log.percent < 100, 'text-green': log.percent > 100 }"
-                >{{ log.percent }}%</span
-              >
-              <span class="text-xl mt-1"
-                ><span
+              <span :class="{ 'text-red': log.percent < 100, 'text-green': log.percent > 100 }">{{ log.percent }}%</span>
+              <span class="text-xl mt-1">
+                <span
                   v-if="log.trend === 'up'"
                   class="i-material-symbols-trending-up text-green"
                 ></span>
@@ -143,8 +145,8 @@ const shortTime = computed(() => {
                   v-else-if="log.trend === 'down'"
                   class="i-material-symbols-trending-down text-red"
                 ></span>
-                <span v-else class="i-material-symbols-trending-flat"></span
-              ></span>
+                <span v-else class="i-material-symbols-trending-flat"></span>
+              </span>
             </div>
             <div :class="['flex gap-1 items-center h-6 text-base-600 no-underline']">
               <span class="i-icon-park-outline-time text-sm"></span>
@@ -166,8 +168,7 @@ const shortTime = computed(() => {
                   },
                   'mr-2'
                 ]"
-                >{{ log.price }} ({{ log.percent }}%)</span
-              >
+              >{{ log.price }} ({{ log.percent }}%)</span>
               <span
                 v-if="log.trend === 'up'"
                 class="i-material-symbols-trending-up text-green text-xl"
@@ -187,8 +188,7 @@ const shortTime = computed(() => {
                   'line-through': isOutdated,
                   'op-50': isOutdated
                 }"
-                >{{ profit }}</span
-              >
+                >{{ profit }}</span>
             </p>
             <p v-if="log.type === 'sell' && product.baseVolume">
               <span class="font-bold mr-2">单票利润</span>
@@ -199,8 +199,7 @@ const shortTime = computed(() => {
                   'line-through': isOutdated,
                   'op-50': isOutdated
                 }"
-                >{{ +(profit ?? 0) * product.baseVolume }}</span
-              >
+              >{{ +(profit ?? 0) * product.baseVolume }}</span>
             </p>
             <p v-if="log.type === 'sell' && transaction?.basePrice">
               <span class="font-bold mr-2">基准价格</span>
@@ -216,9 +215,9 @@ const shortTime = computed(() => {
             </p>
             <p>
               <span class="font-bold mr-2">更新时间</span>
-              <span :class="{ 'op-50': isOutdated }">{{
-                format(log.uploadedAt, { date: 'long', time: 'medium' })
-              }}</span>
+              <span :class="{ 'op-50': isOutdated }">
+                {{ format(log.uploadedAt, { date: 'long', time: 'medium' }) }}
+              </span>
             </p>
             <p>
               <NuxtLink

--- a/components/Price.vue
+++ b/components/Price.vue
@@ -43,7 +43,7 @@ const profit = computed(() => {
 
 // 单票利润
 const perTicketProfit = computed(() => {
-  if (!props.product || props.log?.type === 'buy') return undefined;
+  if (!props.product || props.log?.type === 'buy') return 0;
   return (profit.value ?? 0) * (props.product.baseVolume ?? 0);
 });
 
@@ -100,143 +100,141 @@ const shortTime = computed(() => {
 </script>
 
 <template>
-  <div>
-    <TooltipProvider v-if="log && shortTime" :delayDuration="300" :skipDelayDuration="100" :disableClosingTrigger="true">
-      <Tooltip v-model:open="openTooltip">
-        <TooltipTrigger as-child>
-          <div :class="[{ 'op-50': isOutdated }, 'space-y-1']" @click="openTooltip = true">
-            <!-- 所在城市 -->
-            <div v-if="['byProfit', 'byPerTicketProfit'].includes(settingStore.listSortMode)" class="flex gap-1 items-center text-base-600">
-              <span class="i-icon-park-outline-city-one text-sm"></span>
-              <span >{{ log.targetCity }}</span>
-            </div>
-            <!-- 基准单位利润 -->
-            <div
-              v-if="['byCity', 'byProfit'].includes(settingStore.listSortMode) && log.type === 'sell'"
-              :class="['h-6 flex gap-1 items-center', { 'line-through': isOutdated }]"
-            >
-              <span class="i-icon-park-outline-income-one text-base-600 text-sm"></span>
-              <span :class="[profitColor]">{{ profit }}</span>
-            </div>
-            <!-- 基准单票利润 -->
-            <div
-              v-if="settingStore.listSortMode == 'byPerTicketProfit' && log.type === 'sell' && product.baseVolume"
-              :class="['h-6 flex gap-1 items-center', { 'line-through': isOutdated }]"
-            >
-              <span class="i-icon-park-outline-ticket text-base-600 text-sm"></span>
-              <span
-                :class="{
-                  'text-red': log.percent < 100,
-                  'text-green': log.percent > 100,
-                  'op-50': isOutdated
-                }"
-              >{{ perTicketProfit }}</span>
-            </div>
-            <!-- 涨跌百分比 -->
-            <div :class="['h-6 flex gap-1 items-center', { 'line-through': isOutdated }]">
-              <span class="i-icon-park-outline-chart-line text-base-600 text-sm"></span>
-              <span :class="{ 'text-red': log.percent < 100, 'text-green': log.percent > 100 }">{{ log.percent }}%</span>
-              <span class="text-xl mt-1">
-                <span
-                  v-if="log.trend === 'up'"
-                  class="i-material-symbols-trending-up text-green"
-                ></span>
-                <span
-                  v-else-if="log.trend === 'down'"
-                  class="i-material-symbols-trending-down text-red"
-                ></span>
-                <span v-else class="i-material-symbols-trending-flat"></span>
-              </span>
-            </div>
-            <div :class="['flex gap-1 items-center h-6 text-base-600 no-underline']">
-              <span class="i-icon-park-outline-time text-sm"></span>
-              <span>{{ shortTime }}</span>
-            </div>
+  <TooltipProvider v-if="log && shortTime" :delayDuration="300" :skipDelayDuration="100" :disableClosingTrigger="true">
+    <Tooltip v-model:open="openTooltip">
+      <TooltipTrigger as-child>
+        <div :class="[{ 'op-50': isOutdated }, 'space-y-1']" @click="openTooltip = true">
+          <!-- 所在城市 -->
+          <div v-if="['byProfit', 'byPerTicketProfit'].includes(settingStore.listSortMode)" class="flex gap-1 items-center text-base-600">
+            <span class="i-icon-park-outline-city-one text-sm"></span>
+            <span >{{ log.targetCity }}</span>
           </div>
-        </TooltipTrigger>
-        <TooltipContent>
-          <div v-if="log" class="py-1 space-y-1">
-            <p class="flex items-center">
-              <span class="font-bold mr-2">实时价格</span>
-              <span
-                :class="[
-                  {
-                    'text-red': log.percent < 100,
-                    'text-green': log.percent > 100,
-                    'line-through': isOutdated,
-                    'op-50': isOutdated
-                  },
-                  'mr-2'
-                ]"
-              >{{ log.price }} ({{ log.percent }}%)</span>
+          <!-- 基准单位利润 -->
+          <div
+            v-if="['byCity', 'byProfit'].includes(settingStore.listSortMode) && log.type === 'sell'"
+            :class="['h-6 flex gap-1 items-center', { 'line-through': isOutdated }]"
+          >
+            <span class="i-icon-park-outline-income-one text-base-600 text-sm"></span>
+            <span :class="[profitColor]">{{ profit }}</span>
+          </div>
+          <!-- 基准单票利润 -->
+          <div
+            v-if="settingStore.listSortMode == 'byPerTicketProfit' && log.type === 'sell' && product.baseVolume"
+            :class="['h-6 flex gap-1 items-center', { 'line-through': isOutdated }]"
+          >
+            <span class="i-icon-park-outline-ticket text-base-600 text-sm"></span>
+            <span
+              :class="{
+                'text-red': perTicketProfit < 0,
+                'text-green': perTicketProfit > 0,
+                'op-50': isOutdated
+              }"
+            >{{ perTicketProfit }}</span>
+          </div>
+          <!-- 涨跌百分比 -->
+          <div :class="['h-6 flex gap-1 items-center', { 'line-through': isOutdated }]">
+            <span class="i-icon-park-outline-chart-line text-base-600 text-sm"></span>
+            <span :class="{ 'text-red': log.percent < 100, 'text-green': log.percent > 100 }">{{ log.percent }}%</span>
+            <span class="text-xl mt-1">
               <span
                 v-if="log.trend === 'up'"
-                class="i-material-symbols-trending-up text-green text-xl"
+                class="i-material-symbols-trending-up text-green"
               ></span>
               <span
                 v-else-if="log.trend === 'down'"
-                class="i-material-symbols-trending-down text-red text-xl"
+                class="i-material-symbols-trending-down text-red"
               ></span>
-              <span v-else class="i-material-symbols-trending-flat text-xl"></span>
-            </p>
-            <p v-if="log.type === 'sell'">
-              <span class="font-bold mr-2">单位利润</span>
-              <span
-                :class="{
-                  'text-red': log.percent < 100,
-                  'text-green': log.percent > 100,
-                  'line-through': isOutdated,
-                  'op-50': isOutdated
-                }"
-                >{{ profit }}</span>
-            </p>
-            <p v-if="log.type === 'sell' && product.baseVolume">
-              <span class="font-bold mr-2">单票利润</span>
-              <span
-                :class="{
-                  'text-red': log.percent < 100,
-                  'text-green': log.percent > 100,
-                  'line-through': isOutdated,
-                  'op-50': isOutdated
-                }"
-              >{{ +(profit ?? 0) * product.baseVolume }}</span>
-            </p>
-            <p v-if="log.type === 'sell' && transaction?.basePrice">
-              <span class="font-bold mr-2">基准价格</span>
-              <span>{{ transaction.basePrice }}</span>
-            </p>
-            <p v-if="log.type === 'buy' && product.baseVolume">
-              <span class="font-bold mr-2">基础货量</span>
-              <span>{{ product.baseVolume }}</span>
-            </p>
-            <p v-if="log.type === 'buy' && product.basePrice">
-              <span class="font-bold mr-2">基准价格</span>
-              <span>{{ product.basePrice }}</span>
-            </p>
-            <p>
-              <span class="font-bold mr-2">更新时间</span>
-              <span :class="{ 'op-50': isOutdated }">
-                {{ format(log.uploadedAt, { date: 'long', time: 'medium' }) }}
-              </span>
-            </p>
-            <p>
-              <NuxtLink
-                :to="`/transaction/${log.sourceCity}/${log.name}/${log.targetCity}`"
-                class="text-link font-bold"
-              >查看历史记录</NuxtLink>
-              <span class="text-link font-bold ml-4 cursor-pointer" @click="reportDialogVisible = true">快速上报价格</span>
-            </p>
+              <span v-else class="i-material-symbols-trending-flat"></span>
+            </span>
           </div>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-    
-    <CreateLog
-      v-if="log"
-      :source-city-name="log.sourceCity"
-      :target-city-name="log.targetCity"
-      :product="product"
-      v-model:open="reportDialogVisible"
-    />
-  </div>
+          <div :class="['flex gap-1 items-center h-6 text-base-600 no-underline']">
+            <span class="i-icon-park-outline-time text-sm"></span>
+            <span>{{ shortTime }}</span>
+          </div>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div v-if="log" class="py-1 space-y-1">
+          <p class="flex items-center">
+            <span class="font-bold mr-2">实时价格</span>
+            <span
+              :class="[
+                {
+                  'text-red': log.percent < 100,
+                  'text-green': log.percent > 100,
+                  'line-through': isOutdated,
+                  'op-50': isOutdated
+                },
+                'mr-2'
+              ]"
+            >{{ log.price }} ({{ log.percent }}%)</span>
+            <span
+              v-if="log.trend === 'up'"
+              class="i-material-symbols-trending-up text-green text-xl"
+            ></span>
+            <span
+              v-else-if="log.trend === 'down'"
+              class="i-material-symbols-trending-down text-red text-xl"
+            ></span>
+            <span v-else class="i-material-symbols-trending-flat text-xl"></span>
+          </p>
+          <p v-if="log.type === 'sell'">
+            <span class="font-bold mr-2">单位利润</span>
+            <span
+              :class="{
+                'text-red': log.percent < 100,
+                'text-green': log.percent > 100,
+                'line-through': isOutdated,
+                'op-50': isOutdated
+              }"
+              >{{ profit }}</span>
+          </p>
+          <p v-if="log.type === 'sell' && product.baseVolume">
+            <span class="font-bold mr-2">单票利润</span>
+            <span
+              :class="{
+                'text-red': log.percent < 100,
+                'text-green': log.percent > 100,
+                'line-through': isOutdated,
+                'op-50': isOutdated
+              }"
+            >{{ +(profit ?? 0) * product.baseVolume }}</span>
+          </p>
+          <p v-if="log.type === 'sell' && transaction?.basePrice">
+            <span class="font-bold mr-2">基准价格</span>
+            <span>{{ transaction.basePrice }}</span>
+          </p>
+          <p v-if="log.type === 'buy' && product.baseVolume">
+            <span class="font-bold mr-2">基础货量</span>
+            <span>{{ product.baseVolume }}</span>
+          </p>
+          <p v-if="log.type === 'buy' && product.basePrice">
+            <span class="font-bold mr-2">基准价格</span>
+            <span>{{ product.basePrice }}</span>
+          </p>
+          <p>
+            <span class="font-bold mr-2">更新时间</span>
+            <span :class="{ 'op-50': isOutdated }">
+              {{ format(log.uploadedAt, { date: 'long', time: 'medium' }) }}
+            </span>
+          </p>
+          <p>
+            <NuxtLink
+              :to="`/transaction/${log.sourceCity}/${log.name}/${log.targetCity}`"
+              class="text-link font-bold"
+            >查看历史记录</NuxtLink>
+            <span class="text-link font-bold ml-4 cursor-pointer" @click="reportDialogVisible = true">快速上报价格</span>
+          </p>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+  
+  <CreateLog
+    v-if="log"
+    :source-city-name="log.sourceCity"
+    :target-city-name="log.targetCity"
+    :product="product"
+    v-model:open="reportDialogVisible"
+  />
 </template>

--- a/components/Price.vue
+++ b/components/Price.vue
@@ -28,13 +28,9 @@ const store = useLatestLogs();
 const profit = computed(() => {
   if (!props.log || props.log?.type === 'buy') return undefined;
 
-  const productLog = store.getLatestLog(props.log.sourceCity, props.log.name, props.log.sourceCity);
-  if (productLog) {
-    return Math.round(
-      1.06 * props.log.price -
-        0.85 * productLog.price -
-        (1.06 * props.log.price - 0.85 * productLog.price) * 0.06
-    );
+  const sourceCityLatestLog = store.getLatestLog(props.log.sourceCity, props.log.name, props.log.sourceCity);
+  if (sourceCityLatestLog) {
+    return Math.round(props.log.price - sourceCityLatestLog.price)
   } else {
     return undefined;
   }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -69,30 +69,47 @@ const settingStore = useSettingStore()
           <MenubarMenu>
             <MenubarTrigger>设置</MenubarTrigger>
             <MenubarContent>
-              <MenubarItem as-child>
-                <a
-                  class="hover:bg-gray-100 cursor-pointer flex justify-between"
-                  @click="settingStore.switchListSortModeTo('byCity')"
-                >
-                  <div class="flex items-center">
-                    <span class="i-icon-park-outline-city-one mr-1 block w-4"></span>
-                    <span>按城市排序</span>
-                  </div>
-                  <span v-if="settingStore.listSortMode === 'byCity'" class="i-material-symbols-check"></span>
-                </a>
-              </MenubarItem>
-              <MenubarItem as-child>
-                <a
-                  class="hover:bg-gray-100 cursor-pointer flex justify-between"
-                  @click="settingStore.switchListSortModeTo('byProfit')"
-                >
-                  <div class="flex items-center">
-                    <span class="i-icon-park-outline-income-one mr-1 block w-4"></span>
-                    <span>按利润排序</span>
-                  </div>
-                  <span v-if="settingStore.listSortMode === 'byProfit'" class="i-material-symbols-check"></span>
-                </a>
-              </MenubarItem>
+              <MenubarSub>
+                <MenubarSubTrigger>售出排序依据</MenubarSubTrigger>
+                <MenubarSubContent>
+                  <MenubarItem as-child>
+                    <a
+                      class="hover:bg-gray-100 cursor-pointer flex justify-between"
+                      @click="settingStore.switchListSortModeTo('byCity')"
+                    >
+                      <div class="flex items-center mr-2">
+                        <span class="i-icon-park-outline-city-one mr-1 block w-4"></span>
+                        <span>按城市排序</span>
+                      </div>
+                      <span v-if="settingStore.listSortMode === 'byCity'" class="i-material-symbols-check"></span>
+                    </a>
+                  </MenubarItem>
+                  <MenubarItem as-child>
+                    <a
+                      class="hover:bg-gray-100 cursor-pointer flex justify-between"
+                      @click="settingStore.switchListSortModeTo('byProfit')"
+                    >
+                      <div class="flex items-center mr-2">
+                        <span class="i-icon-park-outline-income-one mr-1 block w-4"></span>
+                        <span>按单位利润排序</span>
+                      </div>
+                      <span v-if="settingStore.listSortMode === 'byProfit'" class="i-material-symbols-check"></span>
+                    </a>
+                  </MenubarItem>
+                  <MenubarItem as-child>
+                    <a
+                      class="hover:bg-gray-100 cursor-pointer flex justify-between"
+                      @click="settingStore.switchListSortModeTo('byPerTicketProfit')"
+                    >
+                      <div class="flex items-center mr-2">
+                        <span class="i-icon-park-outline-ticket mr-1 block w-4"></span>
+                        <span>按单票利润排序</span>
+                      </div>
+                      <span v-if="settingStore.listSortMode === 'byPerTicketProfit'" class="i-material-symbols-check"></span>
+                    </a>
+                  </MenubarItem>
+                </MenubarSubContent>
+              </MenubarSub>
             </MenubarContent>
           </MenubarMenu>
           <MenubarMenu>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -26,9 +26,7 @@ const settingStore = useSettingStore()
     <nav class="border-b pt-12 mb-4">
       <div class="main">
         <div>
-          <NuxtLink to="/" class="text-2xl font-bold hover:text-base-600 select-none"
-            >雷索纳斯市场</NuxtLink
-          >
+          <NuxtLink to="/" class="text-2xl font-bold hover:text-base-600 select-none">雷索纳斯市场</NuxtLink>
         </div>
         <Menubar class="mt-4">
           <MenubarButton>
@@ -41,9 +39,7 @@ const settingStore = useSettingStore()
                 <MenubarSubTrigger>{{ city.name }}</MenubarSubTrigger>
                 <MenubarSubContent>
                   <MenubarItem v-for="product in city.products" :key="product.name" as-child>
-                    <NuxtLink :to="`/product/${city.name}/${product.name}`">{{
-                      product.name
-                    }}</NuxtLink>
+                    <NuxtLink :to="`/product/${city.name}/${product.name}`">{{ product.name }}</NuxtLink>
                   </MenubarItem>
                 </MenubarSubContent>
               </MenubarSub>
@@ -55,21 +51,17 @@ const settingStore = useSettingStore()
               <MenubarSub>
                 <MenubarSubTrigger>在城市买入</MenubarSubTrigger>
                 <MenubarSubContent>
-                  <MenubarItem v-for="city in cities" :key="city.name" as-child
-                    ><NuxtLink :to="`/report/buy/${city.name}`">{{
-                      city.name
-                    }}</NuxtLink></MenubarItem
-                  >
+                  <MenubarItem v-for="city in cities" :key="city.name" as-child>
+                    <NuxtLink :to="`/report/buy/${city.name}`">{{ city.name }}</NuxtLink>
+                  </MenubarItem>
                 </MenubarSubContent>
               </MenubarSub>
               <MenubarSub>
                 <MenubarSubTrigger>在城市卖出</MenubarSubTrigger>
                 <MenubarSubContent>
-                  <MenubarItem v-for="city in cities" :key="city.name" as-child
-                    ><NuxtLink :to="`/report/sell/${city.name}`">{{
-                      city.name
-                    }}</NuxtLink></MenubarItem
-                  >
+                  <MenubarItem v-for="city in cities" :key="city.name" as-child>
+                    <NuxtLink :to="`/report/sell/${city.name}`">{{ city.name }}</NuxtLink>
+                  </MenubarItem>
                 </MenubarSubContent>
               </MenubarSub>
             </MenubarContent>
@@ -107,70 +99,18 @@ const settingStore = useSettingStore()
             <MenubarTrigger>关于</MenubarTrigger>
             <MenubarContent>
               <MenubarItem as-child>
-                <a href="https://github.com/yjl9903/resonance-market" target="_blank"
-                  ><span i-carbon-logo-github mr-1 block w-4></span><span>GitHub</span></a
-                >
+                <a href="https://github.com/yjl9903/resonance-market" target="_blank">
+                  <span i-carbon-logo-github mr-1 block w-4></span><span>GitHub</span>
+                </a>
               </MenubarItem>
               <MenubarItem as-child>
-                <a href="https://space.bilibili.com/1631015691" target="_blank"
-                  ><span i-simple-icons-bilibili mr-1 block w-4></span
-                  ><span>雷索纳斯官方 Bilibili</span></a
-                >
+                <a href="https://space.bilibili.com/1631015691" target="_blank">
+                  <span i-simple-icons-bilibili mr-1 block w-4></span>
+                  <span>雷索纳斯官方 Bilibili</span>
+                </a>
               </MenubarItem>
             </MenubarContent>
           </MenubarMenu>
-          <!-- <MenubarMenu>
-            <MenubarTrigger>Edit</MenubarTrigger>
-            <MenubarContent>
-              <MenubarItem> Undo <MenubarShortcut>⌘Z</MenubarShortcut> </MenubarItem>
-              <MenubarItem> Redo <MenubarShortcut>⇧⌘Z</MenubarShortcut> </MenubarItem>
-              <MenubarSeparator />
-              <MenubarSub>
-                <MenubarSubTrigger>Find</MenubarSubTrigger>
-                <MenubarSubContent>
-                  <MenubarItem>Search the web</MenubarItem>
-                  <MenubarSeparator />
-                  <MenubarItem>Find...</MenubarItem>
-                  <MenubarItem>Find Next</MenubarItem>
-                  <MenubarItem>Find Previous</MenubarItem>
-                </MenubarSubContent>
-              </MenubarSub>
-              <MenubarSeparator />
-              <MenubarItem>Cut</MenubarItem>
-              <MenubarItem>Copy</MenubarItem>
-              <MenubarItem>Paste</MenubarItem>
-            </MenubarContent>
-          </MenubarMenu>
-          <MenubarMenu>
-            <MenubarTrigger>View</MenubarTrigger>
-            <MenubarContent>
-              <MenubarCheckboxItem>Always Show Bookmarks Bar</MenubarCheckboxItem>
-              <MenubarCheckboxItem checked> Always Show Full URLs </MenubarCheckboxItem>
-              <MenubarSeparator />
-              <MenubarItem inset> Reload <MenubarShortcut>⌘R</MenubarShortcut> </MenubarItem>
-              <MenubarItem disabled inset>
-                Force Reload <MenubarShortcut>⇧⌘R</MenubarShortcut>
-              </MenubarItem>
-              <MenubarSeparator />
-              <MenubarItem inset> Toggle Fullscreen </MenubarItem>
-              <MenubarSeparator />
-              <MenubarItem inset> Hide Sidebar </MenubarItem>
-            </MenubarContent>
-          </MenubarMenu>
-          <MenubarMenu>
-            <MenubarTrigger>Profiles</MenubarTrigger>
-            <MenubarContent>
-              <MenubarRadioGroup value="benoit">
-                <MenubarRadioItem value="andy"> Andy </MenubarRadioItem>
-                <MenubarRadioItem value="benoit"> Benoit </MenubarRadioItem>
-                <MenubarRadioItem value="Luis"> Luis </MenubarRadioItem>
-              </MenubarRadioGroup>
-              <MenubarSeparator />
-              <MenubarItem inset> Edit... </MenubarItem>
-              <MenubarSeparator />
-              <MenubarItem inset> Add Profile... </MenubarItem>
-            </MenubarContent>
-          </MenubarMenu> -->
         </Menubar>
       </div>
     </nav>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -17,6 +17,7 @@ import {
   MenubarTrigger,
   MenubarButton
 } from '@/components/ui/menubar';
+import { toast } from 'vue-sonner';
 
 const settingStore = useSettingStore()
 </script>
@@ -109,6 +110,47 @@ const settingStore = useSettingStore()
                     </a>
                   </MenubarItem>
                 </MenubarSubContent>
+                <MenubarSub>
+                  <MenubarSubTrigger>利润计算规则</MenubarSubTrigger>
+                  <MenubarSubContent>
+                    <MenubarItem as-child>
+                      <a
+                        class="hover:bg-gray-100 cursor-pointer flex justify-between"
+                        @click="toast('功能正在开发中，敬请期待')"
+                      >
+                        <div class="flex items-center mr-2">
+                          <span class="i-icon-park-outline-positive-dynamics mr-1 block w-4"></span>
+                          <span>最大砍价抬价</span>
+                        </div>
+                        <span v-if="settingStore.profitComputeRule === 'maxPriceChange'" class="i-material-symbols-check"></span>
+                      </a>
+                    </MenubarItem>
+                    <MenubarItem as-child>
+                      <a
+                        class="hover:bg-gray-100 cursor-pointer flex justify-between"
+                        @click="settingStore.switchProfitComputeRuleTo('noChange')"
+                      >
+                        <div class="flex items-center mr-2">
+                          <span class="i-icon-park-outline-negative-dynamics mr-1 block w-4"></span>
+                          <span>不砍价不抬价</span>
+                        </div>
+                        <span v-if="settingStore.profitComputeRule === 'noChange'" class="i-material-symbols-check"></span>
+                      </a>
+                    </MenubarItem>
+                    <MenubarItem as-child>
+                      <a
+                        class="hover:bg-gray-100 cursor-pointer flex justify-between"
+                        @click="toast('功能正在开发中，敬请期待')"
+                      >
+                        <div class="flex items-center mr-2">
+                          <span class="i-icon-park-outline-percentage mr-1 block w-4"></span>
+                          <span>不计算税收</span>
+                        </div>
+                        <span class="i-material-symbols-check"></span>
+                      </a>
+                    </MenubarItem>
+                  </MenubarSubContent>
+                </MenubarSub>
               </MenubarSub>
             </MenubarContent>
           </MenubarMenu>

--- a/stores/latest.ts
+++ b/stores/latest.ts
@@ -6,7 +6,7 @@ export const useLatestLogs = defineStore('latest_logs', () => {
 
   const fetch = async () => {
     const resp = await $fetch(`/api/product`, { retry: 3 });
-    logs.value = resp.latest.map((l) => ({ ...l, uploadedAt: new Date(l.uploadedAt) }));
+    logs.value = resp.latest.map(log => ({ ...log, uploadedAt: new Date(log.uploadedAt) }));
     maps.clear();
     for (const log of logs.value) {
       const key = `${log.sourceCity} - ${log.name}`;

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -2,17 +2,26 @@ import { skipHydrate  } from 'pinia'
 import { useStorage } from '@vueuse/core'
 
 export type ListSortMode = 'byCity' | 'byProfit' | 'byPerTicketProfit'
+export type ProfitComputeRule = 'maxPriceChange' | 'noChange'
 
 export const useSettingStore = defineStore('setting', () => {
   const listSortMode = useStorage<ListSortMode>('listSortMode', 'byCity')
+  const profitComputeRule = useStorage<ProfitComputeRule>('profitComputeRule', 'noChange')
 
   // 切换列表排序模式
   const switchListSortModeTo = (targetMode: ListSortMode) => {
     listSortMode.value = targetMode
   }
 
+  // 切换利润计算规则
+  const switchProfitComputeRuleTo = (targetRule: ProfitComputeRule) => {
+    profitComputeRule.value = targetRule
+  }
+
   return {
     listSortMode: skipHydrate(listSortMode),
-    switchListSortModeTo
+    switchListSortModeTo,
+    profitComputeRule: skipHydrate(profitComputeRule),
+    switchProfitComputeRuleTo
   }
 })

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -1,7 +1,7 @@
 import { skipHydrate  } from 'pinia'
 import { useStorage } from '@vueuse/core'
 
-export type ListSortMode = 'byCity' | 'byProfit'
+export type ListSortMode = 'byCity' | 'byProfit' | 'byPerTicketProfit'
 
 export const useSettingStore = defineStore('setting', () => {
   const listSortMode = useStorage<ListSortMode>('listSortMode', 'byCity')

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -1,7 +1,10 @@
+import { skipHydrate  } from 'pinia'
+import { useStorage } from '@vueuse/core'
+
 export type ListSortMode = 'byCity' | 'byProfit'
 
 export const useSettingStore = defineStore('setting', () => {
-  const listSortMode = ref<ListSortMode>('byCity')
+  const listSortMode = useStorage<ListSortMode>('listSortMode', 'byCity')
 
   // 切换列表排序模式
   const switchListSortModeTo = (targetMode: ListSortMode) => {
@@ -9,7 +12,7 @@ export const useSettingStore = defineStore('setting', () => {
   }
 
   return {
-    listSortMode,
+    listSortMode: skipHydrate(listSortMode),
     switchListSortModeTo
   }
 })


### PR DESCRIPTION
### Description

1. 支持按单票利润排序，同时单票利润排序模式下单元格中展示变更为单票利润
2. 支持设置参数在客户端本地保存
3. 利润计算规则修改为：卖出价-买入价

### Linked Issues

resovle #41 

half resolve #42 