### PR TITLE
fix: 先下掉客户端本地存储功能，已修复部分异常问题

### DIFF
--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -5,8 +5,11 @@ export type ListSortMode = 'byCity' | 'byProfit' | 'byPerTicketProfit'
 export type ProfitComputeRule = 'maxPriceChange' | 'noChange'
 
 export const useSettingStore = defineStore('setting', () => {
-  const listSortMode = useStorage<ListSortMode>('listSortMode', 'byCity')
-  const profitComputeRule = useStorage<ProfitComputeRule>('profitComputeRule', 'noChange')
+  // const listSortMode = useStorage<ListSortMode>('listSortMode', 'byCity')
+  // const profitComputeRule = useStorage<ProfitComputeRule>('profitComputeRule', 'noChange')
+  
+  const listSortMode = ref<ListSortMode>('byCity')
+  const profitComputeRule = ref<ProfitComputeRule>('noChange')
 
   // 切换列表排序模式
   const switchListSortModeTo = (targetMode: ListSortMode) => {
@@ -19,9 +22,11 @@ export const useSettingStore = defineStore('setting', () => {
   }
 
   return {
-    listSortMode: skipHydrate(listSortMode),
+    listSortMode: listSortMode,
+    // listSortMode: skipHydrate(listSortMode),
     switchListSortModeTo,
-    profitComputeRule: skipHydrate(profitComputeRule),
+    profitComputeRule: listSortMode,
+    // profitComputeRule: skipHydrate(profitComputeRule),
     switchProfitComputeRuleTo
   }
 })


### PR DESCRIPTION
发现一些服务端渲染特有的问题，我在本地也复现过。实在有点晚了，明天再修。

复现步骤是：调整到非按城市排序模式，刷新页面，服务端渲染的是按城市排序，然后加载客户端localStorage。这时控制台会报非常多客户端与服务端渲染不匹配的警告，并且可能会出现下图奇怪的情况。

![image](https://github.com/yjl9903/resonance-market/assets/53012237/6bdec8f1-cf56-4789-bc46-2bb330003f88)

解决方案：我先暂时下掉本地存储加载功能