### PR TITLE
[修复、优化与调整] 利润展示、利润排序等优化

### DIFF
--- a/components/Price.vue
+++ b/components/Price.vue
@@ -35,7 +35,7 @@ const profit = computed(() => {
 
   const sourceCityLatestLog = store.getLatestLog(props.log.sourceCity, props.log.name, props.log.sourceCity);
   if (sourceCityLatestLog) {
-    return Math.round((props.log.price * 1.2) * 0.98 - (sourceCityLatestLog.price * 0.8) * 1.08)
+    return Math.round(props.log.price * 1.2 * 0.98 - sourceCityLatestLog.price * 0.8 * 1.08)
   } else {
     return undefined;
   }

--- a/components/Price.vue
+++ b/components/Price.vue
@@ -109,17 +109,17 @@ const shortTime = computed(() => {
             <span class="i-icon-park-outline-city-one text-sm"></span>
             <span >{{ log.targetCity }}</span>
           </div>
-          <!-- 基准单位利润 -->
+          <!-- 单位利润 -->
           <div
-            v-if="['byCity', 'byProfit'].includes(settingStore.listSortMode) && log.type === 'sell'"
+            v-if="settingStore.dataDisplayItems.includes('profit') && log.type === 'sell'"
             :class="['h-6 flex gap-1 items-center', { 'line-through': isOutdated }]"
           >
             <span class="i-icon-park-outline-income-one text-base-600 text-sm"></span>
             <span :class="[profitColor]">{{ profit }}</span>
           </div>
-          <!-- 基准单票利润 -->
+          <!-- 单票利润 -->
           <div
-            v-if="settingStore.listSortMode == 'byPerTicketProfit' && log.type === 'sell' && product.baseVolume"
+            v-if="settingStore.dataDisplayItems.includes('perTicketProfit') && log.type === 'sell' && product.baseVolume"
             :class="['h-6 flex gap-1 items-center', { 'line-through': isOutdated }]"
           >
             <span class="i-icon-park-outline-ticket text-base-600 text-sm"></span>

--- a/components/Price.vue
+++ b/components/Price.vue
@@ -35,7 +35,7 @@ const profit = computed(() => {
 
   const sourceCityLatestLog = store.getLatestLog(props.log.sourceCity, props.log.name, props.log.sourceCity);
   if (sourceCityLatestLog) {
-    return Math.round(props.log.price - sourceCityLatestLog.price)
+    return Math.round((props.log.price * 1.2) * 0.98 - (sourceCityLatestLog.price * 0.8) * 1.08)
   } else {
     return undefined;
   }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -128,7 +128,7 @@ const settingStore = useSettingStore()
                     <MenubarItem as-child>
                       <a
                         class="hover:bg-gray-100 cursor-pointer flex justify-between"
-                        @click="settingStore.switchProfitComputeRuleTo('noChange')"
+                        @click="toast('功能正在开发中，敬请期待')"
                       >
                         <div class="flex items-center mr-2">
                           <span class="i-icon-park-outline-negative-dynamics mr-1 block w-4"></span>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -119,6 +119,18 @@ const settingStore = useSettingStore()
                         @click="toast('功能正在开发中，敬请期待')"
                       >
                         <div class="flex items-center mr-2">
+                          <span class="i-icon-park-outline-percentage mr-1 block w-4"></span>
+                          <span>买卖税收8%</span>
+                        </div>
+                        <span class="i-material-symbols-check"></span>
+                      </a>
+                    </MenubarItem>
+                    <MenubarItem as-child>
+                      <a
+                        class="hover:bg-gray-100 cursor-pointer flex justify-between"
+                        @click="toast('功能正在开发中，敬请期待')"
+                      >
+                        <div class="flex items-center mr-2">
                           <span class="i-icon-park-outline-positive-dynamics mr-1 block w-4"></span>
                           <span>最大砍价抬价</span>
                         </div>
@@ -135,18 +147,6 @@ const settingStore = useSettingStore()
                           <span>不砍价不抬价</span>
                         </div>
                         <span v-if="settingStore.profitComputeRule === 'noChange'" class="i-material-symbols-check"></span>
-                      </a>
-                    </MenubarItem>
-                    <MenubarItem as-child>
-                      <a
-                        class="hover:bg-gray-100 cursor-pointer flex justify-between"
-                        @click="toast('功能正在开发中，敬请期待')"
-                      >
-                        <div class="flex items-center mr-2">
-                          <span class="i-icon-park-outline-percentage mr-1 block w-4"></span>
-                          <span>不计算税收</span>
-                        </div>
-                        <span class="i-material-symbols-check"></span>
                       </a>
                     </MenubarItem>
                   </MenubarSubContent>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -92,65 +92,82 @@ const settingStore = useSettingStore()
                     >
                       <div class="flex items-center mr-2">
                         <span class="i-icon-park-outline-income-one mr-1 block w-4"></span>
-                        <span>按单位利润排序</span>
+                        <span>按利润排序</span>
                       </div>
                       <span v-if="settingStore.listSortMode === 'byProfit'" class="i-material-symbols-check"></span>
+                    </a>
+                  </MenubarItem>
+                </MenubarSubContent>
+              </MenubarSub>
+              <MenubarSub>
+                <MenubarSubTrigger>数据展示</MenubarSubTrigger>
+                <MenubarSubContent>
+                  <MenubarItem as-child>
+                    <a
+                      class="hover:bg-gray-100 cursor-pointer flex justify-between"
+                      @click="settingStore.switchDataDisplayItems('profit')"
+                    >
+                      <div class="flex items-center mr-2">
+                        <span class="i-icon-park-outline-box mr-1 block w-4"></span>
+                        <span>单位利润</span>
+                      </div>
+                      <span v-show="settingStore.dataDisplayItems.includes('profit')" class="i-material-symbols-check"></span>
                     </a>
                   </MenubarItem>
                   <MenubarItem as-child>
                     <a
                       class="hover:bg-gray-100 cursor-pointer flex justify-between"
-                      @click="settingStore.switchListSortModeTo('byPerTicketProfit')"
+                      @click="settingStore.switchDataDisplayItems('perTicketProfit')"
                     >
                       <div class="flex items-center mr-2">
                         <span class="i-icon-park-outline-ticket mr-1 block w-4"></span>
-                        <span>按单票利润排序</span>
+                        <span>单票利润</span>
                       </div>
-                      <span v-if="settingStore.listSortMode === 'byPerTicketProfit'" class="i-material-symbols-check"></span>
+                      <span v-show="settingStore.dataDisplayItems.includes('perTicketProfit')" class="i-material-symbols-check"></span>
                     </a>
                   </MenubarItem>
                 </MenubarSubContent>
-                <MenubarSub>
-                  <MenubarSubTrigger>利润计算规则</MenubarSubTrigger>
-                  <MenubarSubContent>
-                    <MenubarItem as-child>
-                      <a
-                        class="hover:bg-gray-100 cursor-pointer flex justify-between"
-                        @click="toast('功能正在开发中，敬请期待')"
-                      >
-                        <div class="flex items-center mr-2">
-                          <span class="i-icon-park-outline-percentage mr-1 block w-4"></span>
-                          <span>买卖税收8%</span>
-                        </div>
-                        <span class="i-material-symbols-check"></span>
-                      </a>
-                    </MenubarItem>
-                    <MenubarItem as-child>
-                      <a
-                        class="hover:bg-gray-100 cursor-pointer flex justify-between"
-                        @click="toast('功能正在开发中，敬请期待')"
-                      >
-                        <div class="flex items-center mr-2">
-                          <span class="i-icon-park-outline-positive-dynamics mr-1 block w-4"></span>
-                          <span>最大砍价抬价</span>
-                        </div>
-                        <span v-if="settingStore.profitComputeRule === 'maxPriceChange'" class="i-material-symbols-check"></span>
-                      </a>
-                    </MenubarItem>
-                    <MenubarItem as-child>
-                      <a
-                        class="hover:bg-gray-100 cursor-pointer flex justify-between"
-                        @click="toast('功能正在开发中，敬请期待')"
-                      >
-                        <div class="flex items-center mr-2">
-                          <span class="i-icon-park-outline-negative-dynamics mr-1 block w-4"></span>
-                          <span>不砍价不抬价</span>
-                        </div>
-                        <span v-if="settingStore.profitComputeRule === 'noChange'" class="i-material-symbols-check"></span>
-                      </a>
-                    </MenubarItem>
-                  </MenubarSubContent>
-                </MenubarSub>
+              </MenubarSub>
+              <MenubarSub>
+                <MenubarSubTrigger>利润计算规则</MenubarSubTrigger>
+                <MenubarSubContent>
+                  <MenubarItem as-child>
+                    <a
+                      class="hover:bg-gray-100 cursor-pointer flex justify-between"
+                      @click="toast('功能正在开发中，敬请期待')"
+                    >
+                      <div class="flex items-center mr-2">
+                        <span class="i-icon-park-outline-percentage mr-1 block w-4"></span>
+                        <span>买卖税收8%</span>
+                      </div>
+                      <span class="i-material-symbols-check"></span>
+                    </a>
+                  </MenubarItem>
+                  <MenubarItem as-child>
+                    <a
+                      class="hover:bg-gray-100 cursor-pointer flex justify-between"
+                      @click="toast('功能正在开发中，敬请期待')"
+                    >
+                      <div class="flex items-center mr-2">
+                        <span class="i-icon-park-outline-positive-dynamics mr-1 block w-4"></span>
+                        <span>最大砍价抬价</span>
+                      </div>
+                      <span v-if="settingStore.profitComputeRule === 'maxPriceChange'" class="i-material-symbols-check"></span>
+                    </a>
+                  </MenubarItem>
+                  <MenubarItem as-child>
+                    <a
+                      class="hover:bg-gray-100 cursor-pointer flex justify-between"
+                      @click="toast('功能正在开发中，敬请期待')"
+                    >
+                      <div class="flex items-center mr-2">
+                        <span class="i-icon-park-outline-negative-dynamics mr-1 block w-4"></span>
+                        <span>不砍价不抬价</span>
+                      </div>
+                      <span v-if="settingStore.profitComputeRule === 'noChange'" class="i-material-symbols-check"></span>
+                    </a>
+                  </MenubarItem>
+                </MenubarSubContent>
               </MenubarSub>
             </MenubarContent>
           </MenubarMenu>

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -1,14 +1,16 @@
 import { skipHydrate  } from 'pinia'
 import { useStorage } from '@vueuse/core'
 
-export type ListSortMode = 'byCity' | 'byProfit' | 'byPerTicketProfit'
+export type ListSortMode = 'byCity' | 'byProfit'
 export type ProfitComputeRule = 'maxPriceChange' | 'noChange'
+export type DataDisplayItems = 'profit' | 'perTicketProfit'
 
 export const useSettingStore = defineStore('setting', () => {
   // const listSortMode = useStorage<ListSortMode>('listSortMode', 'byCity')
   // const profitComputeRule = useStorage<ProfitComputeRule>('profitComputeRule', 'noChange')
   
   const listSortMode = ref<ListSortMode>('byCity')
+  const dataDisplayItems = ref<DataDisplayItems[]>(['profit', 'perTicketProfit'])
   const profitComputeRule = ref<ProfitComputeRule>('maxPriceChange')
 
   // 切换列表排序模式
@@ -21,12 +23,24 @@ export const useSettingStore = defineStore('setting', () => {
     profitComputeRule.value = targetRule
   }
 
+  // 切换数据显示项
+  const switchDataDisplayItems = (targetItem: DataDisplayItems) => {
+    if (dataDisplayItems.value.includes(targetItem)) {
+      dataDisplayItems.value = dataDisplayItems.value.filter(item => item !== targetItem)
+    } else {
+      dataDisplayItems.value.push(targetItem)
+    }
+  }
+
   return {
     listSortMode: listSortMode,
     // listSortMode: skipHydrate(listSortMode),
     switchListSortModeTo,
     profitComputeRule: profitComputeRule,
     // profitComputeRule: skipHydrate(profitComputeRule),
-    switchProfitComputeRuleTo
+    switchProfitComputeRuleTo,
+    dataDisplayItems: dataDisplayItems,
+    // dataDisplayItems: skipHydrate(dataDisplayItems),
+    switchDataDisplayItems
   }
 })

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -9,7 +9,7 @@ export const useSettingStore = defineStore('setting', () => {
   // const profitComputeRule = useStorage<ProfitComputeRule>('profitComputeRule', 'noChange')
   
   const listSortMode = ref<ListSortMode>('byCity')
-  const profitComputeRule = ref<ProfitComputeRule>('noChange')
+  const profitComputeRule = ref<ProfitComputeRule>('maxPriceChange')
 
   // 切换列表排序模式
   const switchListSortModeTo = (targetMode: ListSortMode) => {
@@ -25,7 +25,7 @@ export const useSettingStore = defineStore('setting', () => {
     listSortMode: listSortMode,
     // listSortMode: skipHydrate(listSortMode),
     switchListSortModeTo,
-    profitComputeRule: listSortMode,
+    profitComputeRule: profitComputeRule,
     // profitComputeRule: skipHydrate(profitComputeRule),
     switchProfitComputeRuleTo
   }


### PR DESCRIPTION
### 改动

1. 利润计算规则改动，按8%税率计算最大砍价抬价的利润
2. 单元格数据展示（单位利润、单票利润）支持设置调整
3. 修复利润排序问题：部分失效报价排名在生效利润之上
